### PR TITLE
Change : notation with .

### DIFF
--- a/src/blocks/example/render.php
+++ b/src/blocks/example/render.php
@@ -1,5 +1,5 @@
 <div <?php echo get_block_wrapper_attributes(); ?> data-wp-context='{ "show": false }'>
-	<button data-wp-on:click="actions.toggle" data-wp-effect="effects.logShow"> Toggle </button>
+	<button data-wp-on.click="actions.toggle" data-wp-effect="effects.logShow"> Toggle </button>
 	<div data-wp-show="context.show">
 		Some text!
 	</div>


### PR DESCRIPTION
We changed all the `:` notation with `.` because the HTML spec only allows `.` in `data-` attributes: [more info here](https://github.com/WordPress/block-interactivity-experiments/issues/132#issuecomment-1466738441).